### PR TITLE
Add 3 second delay after death - before restart menu appears

### DIFF
--- a/scripts/pause_menu.gd
+++ b/scripts/pause_menu.gd
@@ -20,6 +20,7 @@ func _on_pause():
 	$AnimationPlayer.play("blur")
 	
 func _on_player_died() -> void:
+	await get_tree().create_timer(3.0).timeout
 	# Show pause menu when the player dies
 	show()
 	$AnimationPlayer.play("blur")


### PR DESCRIPTION
- this makes it so you can see the player character animation on death - then the restart menu appears.
- really small change but I think it looks a little better than immediately going to restart screen (you don't really see death animation atm)